### PR TITLE
Ip Range restrictions in temp urls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ six>=1.9.0
 xattr>=0.4
 PyECLib>=1.3.1                          # BSD
 cryptography!=2.0,>=1.6                 # BSD/Apache-2.0
+ipaddress

--- a/swift/common/middleware/tempurl.py
+++ b/swift/common/middleware/tempurl.py
@@ -548,8 +548,8 @@ class TempURL(object):
                                             temp_url_prefix)
         if env['REQUEST_METHOD'] == 'HEAD':
             hmac_vals = [
-                _hmac for method in ('HEAD', 'GET', 'POST', 'PUT')
-                for _hmac in self._get_hmacs(
+                hmac for method in ('HEAD', 'GET', 'POST', 'PUT')
+                for hmac in self._get_hmacs(
                     env, temp_url_expires, path, keys, hash_algorithm,
                     request_method=method, ip_range=temp_url_ip_range)]
         else:
@@ -559,11 +559,11 @@ class TempURL(object):
 
         is_valid_hmac = False
         hmac_scope = None
-        for _hmac, scope in hmac_vals:
+        for hmac, scope in hmac_vals:
             # While it's true that we short-circuit, this doesn't affect the
             # timing-attack resistance since the only way this will
             # short-circuit is when a valid signature is passed in.
-            if streq_const_time(temp_url_sig, _hmac):
+            if streq_const_time(temp_url_sig, hmac):
                 is_valid_hmac = True
                 hmac_scope = scope
                 break

--- a/swift/common/middleware/tempurl.py
+++ b/swift/common/middleware/tempurl.py
@@ -745,18 +745,13 @@ class TempURL(object):
             request_method = env['REQUEST_METHOD']
 
         digest = functools.partial(hashlib.new, hash_algorithm)
-        if ip_range:
-            return [
-                (get_hmac(
-                    request_method, path, expires, key,
-                    ip_range=ip_range, digest=digest,
-                ), scope)
-                for (key, scope) in scoped_keys]
-        else:
-            return [
-                (get_hmac(request_method, path, expires, key,
-                          digest=digest), scope)
-                for (key, scope) in scoped_keys]
+        hmac_kwargs = dict(digest=digest, ip_range=ip_range)
+
+        return [
+            (get_hmac(
+                request_method, path, expires, key, **hmac_kwargs
+            ), scope)
+            for (key, scope) in scoped_keys]
 
     def _invalid(self, env, start_response):
         """

--- a/swift/common/middleware/tempurl.py
+++ b/swift/common/middleware/tempurl.py
@@ -252,9 +252,7 @@ import binascii
 from calendar import timegm
 import functools
 import hashlib
-import hmac
 import six
-from hashlib import sha1
 from os.path import basename
 from time import time, strftime, strptime, gmtime
 from ipaddress import ip_address, ip_network

--- a/swift/common/utils.py
+++ b/swift/common/utils.py
@@ -252,7 +252,8 @@ except InvalidHashPathConfigError:
     pass
 
 
-def get_hmac(request_method, path, expires, key, digest=sha1):
+def get_hmac(request_method, path, expires, key, digest=sha1,
+             ip_range=None):
     """
     Returns the hexdigest string of the HMAC (see RFC 2104) for
     the request.
@@ -264,11 +265,15 @@ def get_hmac(request_method, path, expires, key, digest=sha1):
     :param key: HMAC shared secret.
     :param digest: constructor for the digest to use in calculating the HMAC
                    Defaults to SHA1
-
+    :param ip_range: The ip range from which the resource is allowed
+                     to be accessed
     :returns: hexdigest str of the HMAC for the request using the specified
               digest algorithm.
     """
-    parts = (request_method, str(expires), path)
+    if ip_range:
+        parts = (request_method, str(expires), path, ip_range)
+    else:
+        parts = (request_method, str(expires), path)
     if not isinstance(key, six.binary_type):
         key = key.encode('utf8')
     return hmac.new(

--- a/test/unit/common/middleware/test_tempurl.py
+++ b/test/unit/common/middleware/test_tempurl.py
@@ -225,6 +225,28 @@ class TestTempURL(unittest.TestCase):
         self.assertEqual(req.environ['swift.authorize_override'], True)
         self.assertEqual(req.environ['REMOTE_USER'], '.wsgi.tempurl')
 
+    @mock.patch('swift.common.middleware.tempurl.time', return_value=0)
+    def test_get_valid_with_ip(self, mock_time):
+        method = 'GET'
+        expires = (((24 + 1) * 60 + 1) * 60) + 1
+        path = '/v1/a/c/o'
+        key = 'abc'
+        ip = '127.0.0.1'
+        hmac_body = '%s\n%s\n%s\n%s' % (method, expires, path, ip)
+        sig = hmac.new(key, hmac_body, hashlib.sha1).hexdigest()
+        req = self._make_request(path, keys=[key], environ={
+            'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
+            'temp_url_ip_range=%s' % (sig, expires, ip)},
+            headers={'x-forwarded-for': ip})
+        self.tempurl.app = FakeApp(iter([('200 Ok', (), '123')]))
+        resp = req.get_response(self.tempurl)
+        self.assertEqual(resp.status_int, 200)
+        self.assertIn('expires', resp.headers)
+        self.assertEqual('Fri, 02 Jan 1970 01:01:01 GMT',
+                         resp.headers['expires'])
+        self.assertEqual(req.environ['swift.authorize_override'], True)
+        self.assertEqual(req.environ['REMOTE_USER'], '.wsgi.tempurl')
+
     def test_head_valid_with_filename(self):
         method = 'HEAD'
         expires = int(time() + 86400)
@@ -812,6 +834,28 @@ class TestTempURL(unittest.TestCase):
         self.assertIn('Temp URL invalid', resp.body)
         self.assertIn('Www-Authenticate', resp.headers)
 
+    def test_bad_ip_range_invalid(self):
+        method = 'GET'
+        expires = int(time() + 86400)
+        path = '/v1/a/c/o'
+        key = 'abc'
+        ip = '127.0.0.1'
+        bad_ip = '127.0.0.2'
+        hmac_body = '%s\n%s\n%s\n%s' % (method, expires, path, ip)
+        sig = hmac.new(key, hmac_body, hashlib.sha1).hexdigest()
+        req = self._make_request(
+            path, keys=[key],
+            environ={
+                'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&temp_url_ip_range=%s'
+                % (sig, expires, ip),
+            },
+            headers={'x-forwarded-for': bad_ip}
+        )
+        resp = req.get_response(self.tempurl)
+        self.assertEqual(resp.status_int, 401)
+        self.assertIn('Temp URL invalid', resp.body)
+        self.assertIn('Www-Authenticate', resp.headers)
+
     def test_different_key_invalid(self):
         method = 'GET'
         expires = int(time() + 86400)
@@ -1098,44 +1142,50 @@ class TestTempURL(unittest.TestCase):
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s' % (
                         s, e)}),
-                (s, e_ts, None, None, None))
+                (s, e_ts, None, None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING':
                      'temp_url_sig=%s&temp_url_expires=%s&temp_url_prefix=%s'
                      % (s, e, 'prefix')}),
-                (s, e_ts, 'prefix', None, None))
+                (s, e_ts, 'prefix', None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
                      'filename=bobisyouruncle' % (s, e)}),
-                (s, e_ts, None, 'bobisyouruncle', None))
+                (s, e_ts, None, 'bobisyouruncle', None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info({}),
-                (None, None, None, None, None))
+                (None, None, None, None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_expires=%s' % e}),
-                (None, e_ts, None, None, None))
+                (None, e_ts, None, None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s' % s}),
-                (s, None, None, None, None))
+                (s, None, None, None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=bad' % (
                         s)}),
-                (s, 0, None, None, None))
+                (s, 0, None, None, None, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
                      'inline=' % (s, e)}),
-                (s, e_ts, None, None, True))
+                (s, e_ts, None, None, True, None))
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
                      'filename=bobisyouruncle&inline=' % (s, e)}),
-                (s, e_ts, None, 'bobisyouruncle', True))
+                (s, e_ts, None, 'bobisyouruncle', True, None))
+            self.assertEqual(
+                self.tempurl._get_temp_url_info(
+                    {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
+                     'filename=bobisyouruncle&inline=&temp_url_ip_range=127.0.0.1' % (s, e)}),
+                (s, e_ts, None, 'bobisyouruncle', True, '127.0.0.1'))
+
         e_ts = int(time() - 1)
         e_8601 = strftime(tempurl.EXPIRES_ISO8601_FORMAT, gmtime(e_ts))
         for e in (e_ts, e_8601):
@@ -1143,14 +1193,14 @@ class TestTempURL(unittest.TestCase):
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s' % (
                         s, e)}),
-                (s, 0, None, None, None))
+                (s, 0, None, None, None, None))
         # Offsets not supported (yet?).
         e_8601 = strftime('%Y-%m-%dT%H:%M:%S+0000', gmtime(e_ts))
         self.assertEqual(
             self.tempurl._get_temp_url_info(
                 {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s' % (
                     s, e_8601)}),
-            (s, 0, None, None, None))
+            (s, 0, None, None, None, None))
 
     def test_get_hmacs(self):
         self.assertEqual(
@@ -1165,6 +1215,15 @@ class TestTempURL(unittest.TestCase):
             [('240866478d94bbe683ab1d25fba52c7d0df21a60951'
               '4fe6a493dc30f951d2748abc51da0cbc633cd1e0acf'
               '6fadd3af3aedff00ee3d3434dc6a4c423e74adfc4a', 'account')])
+        self.assertEqual(
+            self.tempurl._get_hmacs(
+                {'REQUEST_METHOD': 'HEAD'}, 1, '/v1/a/c/o',
+                [('abc', 'account')], 'sha512', request_method='GET',
+                ip_range='127.0.0.1'
+            ),
+            [('aa0ce1e60a3026b9729fbc4caaae666f428c87480b3'
+              'ee7e70a35b486fe43eafa9617b939613b4c10b94798'
+              'd19ec6509f65dfcadb1cd66419982f596a8fa62124', 'account')])
 
     def test_invalid(self):
 

--- a/test/unit/common/middleware/test_tempurl.py
+++ b/test/unit/common/middleware/test_tempurl.py
@@ -846,7 +846,8 @@ class TestTempURL(unittest.TestCase):
         req = self._make_request(
             path, keys=[key],
             environ={
-                'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&temp_url_ip_range=%s'
+                'QUERY_STRING':
+                'temp_url_sig=%s&temp_url_expires=%s&temp_url_ip_range=%s'
                 % (sig, expires, ip),
             },
             headers={'x-forwarded-for': bad_ip}
@@ -1183,7 +1184,8 @@ class TestTempURL(unittest.TestCase):
             self.assertEqual(
                 self.tempurl._get_temp_url_info(
                     {'QUERY_STRING': 'temp_url_sig=%s&temp_url_expires=%s&'
-                     'filename=bobisyouruncle&inline=&temp_url_ip_range=127.0.0.1' % (s, e)}),
+                     'filename=bobisyouruncle&inline='
+                     '&temp_url_ip_range=127.0.0.1' % (s, e)}),
                 (s, e_ts, None, 'bobisyouruncle', True, '127.0.0.1'))
 
         e_ts = int(time() - 1)

--- a/test/unit/common/test_utils.py
+++ b/test/unit/common/test_utils.py
@@ -3576,6 +3576,11 @@ cluster_dfw1 = http://dfw1.host/v1/
             utils.get_hmac('GET', '/path', 1, 'abc'),
             'b17f6ff8da0e251737aa9e3ee69a881e3e092e2f')
 
+    def test_get_hmac_ip_range(self):
+        self.assertEqual(
+            utils.get_hmac('GET', '/path', 1, 'abc', ip_range='127.0.0.1'),
+            '4e1cf11fb94e9d8753d50569011cf006d723f61f')
+
     def test_parse_override_options(self):
         # When override_<thing> is passed in, it takes precedence.
         opts = utils.parse_override_options(


### PR DESCRIPTION
This patch adds an additional optional parameter to tempurl, which restricts the ip's from which a temp url can be used from.